### PR TITLE
Change Keycloak name for external root module

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ var config = {
       commonjs: "keycloak-js",
       commonjs2: "keycloak-js",
       amd: "keycloak-js",
-      root: "keycloak-js"
+      root: "Keycloak"
     },
     "rxjs": {
       commonjs: "rxjs",


### PR DESCRIPTION
Change the name of Keycloak library for root module ( when imported from window object in browser ).
We need to use "Keycloack" instead of "keycloak-js" as in node / typescrypt.