### PR TITLE
fix global and logging settings on ipsec vpn response

### DIFF
--- a/src/sdk/model/edge/ipsec-vpn/__json__/edge-ipsec-vpn-json.ts
+++ b/src/sdk/model/edge/ipsec-vpn/__json__/edge-ipsec-vpn-json.ts
@@ -8,7 +8,7 @@ import { IpSecVpnSiteJson } from './ip-sec-vpn-site-json';
 export interface EdgeIpsecVpnServiceJson {
   edge_uuid: string;
   enabled: boolean | null;
-  logging_settings: Array<LoggingSettingsJson>;
-  global_settings: Array<GlobalSettingsJson>;
+  logging_settings: LoggingSettingsJson;
+  global_settings: GlobalSettingsJson;
   sites: Array<IpSecVpnSiteJson>;
 }

--- a/src/sdk/model/edge/ipsec-vpn/__mocks__/edge-ipsec-vpn.ts
+++ b/src/sdk/model/edge/ipsec-vpn/__mocks__/edge-ipsec-vpn.ts
@@ -4,20 +4,16 @@ import { EdgeIpsecVpnServiceJson } from '../__json__/edge-ipsec-vpn-json';
 export const MockEdgeIpsecVpn: EdgeIpsecVpnServiceJson = {
   'edge_uuid': 'dev-vcd01.iland.dev:urn:vcloud:gateway:af286787-9cb3-4c9d-b86e-c42dc5dfabc5',
   'enabled': true,
-  'logging_settings': [
-    {
-      'log_level': 'mock-log-level',
-      'enabled': true
-    }
-  ],
-  'global_settings': [
-    {
-      'psk': 'mock-psk',
-      'service_certificate': 'mock-service-certificate',
-      'ca_certificates': ['mock-ca-certificate'],
-      'crl_certificates': ['mock-crl-certificate']
-    }
-  ],
+  'logging_settings': {
+    'log_level': 'mock-log-level',
+    'enabled': true
+  },
+  'global_settings': {
+    'psk': 'mock-psk',
+    'service_certificate': 'mock-service-certificate',
+    'ca_certificates': ['mock-ca-certificate'],
+    'crl_certificates': ['mock-crl-certificate']
+  },
   'sites': [
     {
       'name': 'Tunnel name',

--- a/src/sdk/model/edge/ipsec-vpn/__tests__/ipsec-vpn.test.unit.ts
+++ b/src/sdk/model/edge/ipsec-vpn/__tests__/ipsec-vpn.test.unit.ts
@@ -28,23 +28,23 @@ test('Properly get Ipsec Vpn service', () => {
     expect(ipsecVpn.json).toEqual(Object.assign({}, MockEdgeIpsecVpn));
     expect(ipsecVpn.toString()).toEqual(JSON.stringify(MockEdgeIpsecVpn, undefined, 2));
     if (MockEdgeIpsecVpn.logging_settings) {
-      expect(ipsecVpn.loggingSettings.length).toEqual(MockEdgeIpsecVpn.logging_settings.length);
-      expect(ipsecVpn.loggingSettings[0]).not.toBeNull();
-      if (ipsecVpn.loggingSettings[0]) {
-        expect(ipsecVpn.loggingSettings[0].log_level).toEqual(MockEdgeIpsecVpn.logging_settings[0].log_level);
-        expect(ipsecVpn.loggingSettings[0].enabled).toEqual(MockEdgeIpsecVpn.logging_settings[0].enabled);
+      expect(ipsecVpn.loggingSettings).toEqual(MockEdgeIpsecVpn.logging_settings);
+      expect(ipsecVpn.loggingSettings).not.toBeNull();
+      if (ipsecVpn.loggingSettings) {
+        expect(ipsecVpn.loggingSettings.log_level).toEqual(MockEdgeIpsecVpn.logging_settings.log_level);
+        expect(ipsecVpn.loggingSettings.enabled).toEqual(MockEdgeIpsecVpn.logging_settings.enabled);
       }
     }
     if (MockEdgeIpsecVpn.global_settings) {
-      expect(ipsecVpn.globalSettings.length).toEqual(MockEdgeIpsecVpn.global_settings.length);
-      expect(ipsecVpn.globalSettings[0]).not.toBeNull();
-      if (ipsecVpn.globalSettings[0]) {
-        expect(ipsecVpn.globalSettings[0].psk).toEqual(MockEdgeIpsecVpn.global_settings[0].psk);
-        expect(ipsecVpn.globalSettings[0].service_certificate)
-            .toEqual(MockEdgeIpsecVpn.global_settings[0].service_certificate);
-        expect(ipsecVpn.globalSettings[0].ca_certificates).toEqual(MockEdgeIpsecVpn.global_settings[0].ca_certificates);
-        expect(ipsecVpn.globalSettings[0].crl_certificates)
-            .toEqual(MockEdgeIpsecVpn.global_settings[0].crl_certificates);
+      expect(ipsecVpn.globalSettings).toEqual(MockEdgeIpsecVpn.global_settings);
+      expect(ipsecVpn.globalSettings).not.toBeNull();
+      if (ipsecVpn.globalSettings) {
+        expect(ipsecVpn.globalSettings.psk).toEqual(MockEdgeIpsecVpn.global_settings.psk);
+        expect(ipsecVpn.globalSettings.service_certificate)
+            .toEqual(MockEdgeIpsecVpn.global_settings.service_certificate);
+        expect(ipsecVpn.globalSettings.ca_certificates).toEqual(MockEdgeIpsecVpn.global_settings.ca_certificates);
+        expect(ipsecVpn.globalSettings.crl_certificates)
+            .toEqual(MockEdgeIpsecVpn.global_settings.crl_certificates);
       }
     }
     if (MockEdgeIpsecVpn.sites) {

--- a/src/sdk/model/edge/ipsec-vpn/ipsec-vpn.ts
+++ b/src/sdk/model/edge/ipsec-vpn/ipsec-vpn.ts
@@ -30,17 +30,17 @@ export class IpsecVpn {
 
   /**
    * Get global settings
-   * @returns {Array<GlobalSettingsJson>}
+   * @returns {GlobalSettingsJson}
    */
-  get globalSettings(): Array<GlobalSettingsJson> {
+  get globalSettings(): GlobalSettingsJson {
     return this._json.global_settings;
   }
 
   /**
    * Get logging settings
-   * @returns {Array<LoggingSettingsJson>}
+   * @returns {LoggingSettingsJson}
    */
-  get loggingSettings(): Array<LoggingSettingsJson> {
+  get loggingSettings(): LoggingSettingsJson {
     return this._json.logging_settings;
   }
 


### PR DESCRIPTION
Global and logging settings are not arrays 