### PR TITLE
fix accept header for company.getLogo

### DIFF
--- a/src/sdk/model/company/__tests__/company.test.unit.ts
+++ b/src/sdk/model/company/__tests__/company.test.unit.ts
@@ -10,6 +10,7 @@ import { MockVappJson } from '../../vapp/__mocks__/vapp';
 import { MockVmJson } from '../../vm/__mocks__/vm';
 import { SupportTicketMock } from '../support-ticket/__mocks__/support-ticket';
 import { UserCreateRequest } from '../user-create-request';
+import { Http } from '../../../service/http/__mocks__/http';
 
 jest.mock('../../../service/http/http');
 
@@ -192,7 +193,7 @@ test('Properly submits request to get company logo', async() => {
     return company.getLogo().then(async(logo) => {
       expect(Iland.getHttp().get).lastCalledWith(`/companies/${id}/logo`,
         {
-          'headers': { 'Accept': 'image/jpeg' },
+          'headers': { 'Accept': Http.versionMime('image/jpeg') },
           'responseType': 'arraybuffer'
         }
       );

--- a/src/sdk/model/company/company.ts
+++ b/src/sdk/model/company/company.ts
@@ -70,6 +70,7 @@ import { O365AuditLogJson } from './__json__/o365-audit-log-json';
 import { O365AuditLog } from './o365-audit-log';
 import { O365BackupRepositoryJson } from './__json__/o365-backup-repository-json';
 import { O365BackupRepository } from './o365-backup-repository';
+import { Http } from '../../service/http/http';
 
 /**
  * Company.
@@ -530,7 +531,7 @@ export class Company extends Entity {
   async getLogo(): Promise<Uint8Array | null> {
     return Iland.getHttp().get(`/companies/${this.uuid}/logo`, {
       headers: {
-        'Accept': 'image/jpeg'
+        'Accept': Http.versionMime('image/jpeg')
       },
       responseType: 'arraybuffer'
     }).then((response) => {

--- a/src/sdk/service/http/__tests__/http.test.unit.ts
+++ b/src/sdk/service/http/__tests__/http.test.unit.ts
@@ -7,4 +7,5 @@ test('Test version utility function', function() {
   expect(Http.versionMime('application/json')).toBe('application/vnd.ilandcloud.api.v1.0+json');
   expect(Http.versionMime('application/json', 0.5)).toBe('application/vnd.ilandcloud.api.v0.5+json');
   expect(Http.versionMime('application/octet-stream')).toBe('application/vnd.ilandcloud.api.v1.0+octet-stream');
+  expect(Http.versionMime('image/jpeg')).toBe('image/vnd.ilandcloud.api.v1.0+jpeg');
 });


### PR DESCRIPTION
currently company logo GET requests are 404-ing bc the accept header is wrong. see [swagger doc](http://doc.10.api.iland.test/1.0/#/Companies/getLogo)