### PR TITLE
rename vdc.hasIaasBackups to vdc.hasAdvancedBackups

### DIFF
--- a/src/sdk/model/vdc/__json__/vdc-json.ts
+++ b/src/sdk/model/vdc/__json__/vdc-json.ts
@@ -23,7 +23,7 @@ export interface VdcJson extends EntityJson {
   used_network_count: number;
   location_id: string;
   org_uuid: string;
-  has_iaas_backups: boolean;
+  has_advanced_backups: boolean;
 }
 
 /**

--- a/src/sdk/model/vdc/__mocks__/vdc.ts
+++ b/src/sdk/model/vdc/__mocks__/vdc.ts
@@ -27,7 +27,7 @@ export const MockVdcJson: VdcJson = {
   deleted: false,
   deleted_date: null,
   updated_date: 1499693404432,
-  has_iaas_backups: false,
+  has_advanced_backups: false,
   company_id: '12345'
 };
 
@@ -55,7 +55,7 @@ export const MockSecondVdcJson: VdcJson = {
   deleted: false,
   deleted_date: null,
   updated_date: 1499693404654,
-  has_iaas_backups: false,
+  has_advanced_backups: false,
   company_id: '12345'
 };
 

--- a/src/sdk/model/vdc/__tests__/vdc.test.int.ts
+++ b/src/sdk/model/vdc/__tests__/vdc.test.int.ts
@@ -102,8 +102,8 @@ test('Can get vDC and verify required properties', async() => {
     expect(vdc.networkQuota).toBe(raw.network_quota);
     expect(vdc.usedNetworkCount).toBeDefined();
     expect(vdc.usedNetworkCount).toBe(raw.used_network_count);
-    expect(vdc.hasIaasBackups).toBeDefined();
-    expect(vdc.hasIaasBackups).toBe(raw.has_iaas_backups);
+    expect(vdc.hasAdvancedBackups).toBeDefined();
+    expect(vdc.hasAdvancedBackups).toBe(raw.has_advanced_backups);
     return vdc;
   });
 });

--- a/src/sdk/model/vdc/vdc.ts
+++ b/src/sdk/model/vdc/vdc.ts
@@ -318,11 +318,11 @@ export class Vdc extends Entity implements EntityWithPerfSamples {
   }
 
   /**
-   * Get has IAAS backups.
+   * Whether the vDC has the advanced backups offering.
    * @returns {boolean}
    */
-  get hasIaasBackups(): boolean {
-    return this._json.has_iaas_backups;
+  get hasAdvancedBackups(): boolean {
+    return this._json.has_advanced_backups;
   }
 
   /**


### PR DESCRIPTION
renaming the flag indicating whether a vdc has the advanced backups offering, as the meaning of `has_iaas_backups` has been updated to indicate whether a vdc has either advanced or integrated backups: [platform PR](http://git.iland.test/projects/IC/repos/iland-core/pull-requests/4427/diff#web-v1/rest-api/public-api/src/main/java/com/iland/core/web/rest/response/vdc/VdcResponse.java)