### PR TITLE
add the org dns zone model

### DIFF
--- a/src/sdk/model/org/__json__/org-dns-zone-json.ts
+++ b/src/sdk/model/org/__json__/org-dns-zone-json.ts
@@ -1,0 +1,9 @@
+/**
+ * Org DNS Zone JSON.
+ */
+export interface OrgDnsZoneJson {
+  org_uuid: string;
+  zone_id: number;
+  deleted: boolean;
+  zone_name: string;
+}

--- a/src/sdk/model/org/__mocks__/org-dns-zones.ts
+++ b/src/sdk/model/org/__mocks__/org-dns-zones.ts
@@ -1,33 +1,12 @@
 import { AxiosResponse } from 'axios';
-import { DnsZoneJson } from '../__json__/dns-zone-json';
 import { CheckDnsZoneJson } from '../__json__/check-dns-zone-json';
+import { OrgDnsZoneJson } from '../__json__/org-dns-zone-json';
 
-export const MockOrgDnsZonesJson: Array<DnsZoneJson> = [{
-  id: 1,
-  name: 'string',
-  resource_id: 1,
-  serial: 1,
-  refresh: 1,
-  retry: 1,
-  expire: 1,
-  minimum: 1,
-  soa: 'string',
-  tags: 'string',
-  ttl: 'string',
-  enable_dns_sec: false,
-  auto_check: false,
-  record_id: 1,
-  record_host: 'string',
-  record_type: 'PTR',
-  record_value: 'string',
-  record_description: 'string',
-  record_ttl: 'string',
-  record_ordering: 1,
-  record_errors: 'string',
-  user_can_create: false,
-  user_can_delete: false,
-  user_can_update: false,
-  unpaged_rows: 1
+export const MockOrgDnsZonesJson: Array<OrgDnsZoneJson> = [{
+  org_uuid: 'string',
+  zone_id: 1,
+  deleted: false,
+  zone_name: 'string'
 }];
 
 export const MockOrgDnsZonesResponse: Promise<AxiosResponse> = new Promise<AxiosResponse>(function(resolve) {

--- a/src/sdk/model/org/__tests__/org.test.unit.ts
+++ b/src/sdk/model/org/__tests__/org.test.unit.ts
@@ -184,37 +184,17 @@ test('Properly submits request to delete org dns record', async() => {
 
 test('Properly submits request to get org dns zones', async() => {
   const org = new Org(MockOrgJson);
-  return org.getDnsZones().then(function(zones) {
+  return org.getOrgDnsZones().then(function(zones) {
     expect(Iland.getHttp().get).lastCalledWith(`/orgs/${org.uuid}/dns-zones`);
     expect(zones.length).toBe(MockOrgDnsZonesJson.length);
     let idx = 0;
     for (const zone of zones) {
       const jsonZone = MockOrgDnsZonesJson[idx];
       expect(zone.json).toEqual(jsonZone);
-      expect(zone.autoCheck).toBe(jsonZone.auto_check);
-      expect(zone.enableDnsSec).toBe(jsonZone.enable_dns_sec);
-      expect(zone.id).toBe(jsonZone.id);
-      expect(zone.minimum).toBe(jsonZone.minimum);
-      expect(zone.expire).toBe(jsonZone.expire);
-      expect(zone.name).toBe(jsonZone.name);
-      expect(zone.recordDescription).toBe(jsonZone.record_description);
-      expect(zone.recordErrors).toBe(jsonZone.record_errors);
-      expect(zone.recordHost).toBe(jsonZone.record_host);
-      expect(zone.recordId).toBe(jsonZone.record_id);
-      expect(zone.recordOrdering).toBe(jsonZone.record_ordering);
-      expect(zone.recordType).toBe(jsonZone.record_type);
-      expect(zone.recordValue).toBe(jsonZone.record_value);
-      expect(zone.userCanCreate).toBe(jsonZone.user_can_create);
-      expect(zone.userCanUpdate).toBe(jsonZone.user_can_update);
-      expect(zone.userCanDelete).toBe(jsonZone.user_can_delete);
-      expect(zone.serial).toBe(jsonZone.serial);
-      expect(zone.retry).toBe(jsonZone.retry);
-      expect(zone.soa).toBe(jsonZone.soa);
-      expect(zone.tags).toBe(jsonZone.tags);
-      expect(zone.unpagedRows).toBe(jsonZone.unpaged_rows);
-      expect(zone.recordTtl).toBe(jsonZone.record_ttl);
-      expect(zone.recordOrdering).toBe(jsonZone.record_ordering);
-      expect(zone.recordErrors).toBe(jsonZone.record_errors);
+      expect(zone.orgUuid).toBe(jsonZone.org_uuid);
+      expect(zone.zoneId).toBe(jsonZone.zone_id);
+      expect(zone.deleted).toBe(jsonZone.deleted);
+      expect(zone.zoneName).toBe(jsonZone.zone_name);
       expect(zone.toString()).toBeDefined();
       idx++;
     }
@@ -228,6 +208,32 @@ test('Properly submits request to add dns zone', async() => {
   return org.addDnsZone(request).then(function(zone) {
     expect(Iland.getHttp().post).lastCalledWith(`/orgs/${org.uuid}/dns-zones`, request.json);
     expect(zone.name).toBe(request.name);
+    expect(zone.id).toBeDefined();
+    expect(zone.resourceId).toBeDefined();
+    expect(zone.serial).toBeDefined();
+    expect(zone.refresh).toBeDefined();
+    expect(zone.retry).toBeDefined();
+    expect(zone.expire).toBeDefined();
+    expect(zone.minimum).toBeDefined();
+    expect(zone.soa).toBeDefined();
+    expect(zone.tags).toBeDefined();
+    expect(zone.ttl).toBeDefined();
+    expect(zone.enableDnsSec).toBeDefined();
+    expect(zone.autoCheck).toBeDefined();
+    expect(zone.recordId).toBeDefined();
+    expect(zone.recordHost).toBeDefined();
+    expect(zone.recordType).toBeDefined();
+    expect(zone.recordValue).toBeDefined();
+    expect(zone.recordDescription).toBeDefined();
+    expect(zone.recordTtl).toBeDefined();
+    expect(zone.recordOrdering).toBeDefined();
+    expect(zone.recordErrors).toBeDefined();
+    expect(zone.userCanCreate).toBeDefined();
+    expect(zone.userCanDelete).toBeDefined();
+    expect(zone.userCanUpdate).toBeDefined();
+    expect(zone.unpagedRows).toBeDefined();
+    expect(zone.json).toBeDefined();
+    expect(zone.toString()).toBeDefined();
   });
 });
 

--- a/src/sdk/model/org/org-dns-zone.ts
+++ b/src/sdk/model/org/org-dns-zone.ts
@@ -1,0 +1,58 @@
+import { OrgDnsZoneJson } from './__json__/org-dns-zone-json';
+
+/**
+ * Org DNS Zone. Provides link between an Org and a DNS Zone.
+ */
+export class OrgDnsZone {
+
+  constructor(private _json: OrgDnsZoneJson) {
+  }
+
+  /**
+   * Get the org uuid.
+   * @returns {string}
+   */
+  get orgUuid(): string {
+    return this._json.org_uuid;
+  }
+
+  /**
+   * Get the DNS zone ID.
+   * @returns {number}
+   */
+  get zoneId(): number {
+    return this._json.zone_id;
+  }
+
+  /**
+   * Get whether the DNS zone has been deleted.
+   * @returns {boolean}
+   */
+  get deleted(): boolean {
+    return this._json.deleted;
+  }
+
+  /**
+   * Get the DNS zone name.
+   * @returns {string}
+   */
+  get zoneName(): string {
+    return this._json.zone_name;
+  }
+
+  /**
+   * Get the json representation of this class.
+   * @returns {OrgDnsZoneJson}
+   */
+  get json(): OrgDnsZoneJson {
+    return Object.assign({}, this._json);
+  }
+
+  /**
+   * Get the string representation of this class.
+   * @returns {string}
+   */
+  toString(): string {
+    return JSON.stringify(this._json, undefined, 2);
+  }
+}

--- a/src/sdk/model/org/org.ts
+++ b/src/sdk/model/org/org.ts
@@ -131,6 +131,8 @@ import { OrgBackupSummaryStats } from '../advanced-backups/backup-run/org-backup
 import { OrgBackupSummaryStatsJson } from '../advanced-backups/backup-run/__json__/org-backup-summary-stats-json';
 import { OrgBackupStatus } from '../advanced-backups/backup-status/org-backup-status';
 import { OrgBackupStatusJson } from '../advanced-backups/backup-status/__json__/org-backup-status-json';
+import { OrgDnsZone } from './org-dns-zone';
+import { OrgDnsZoneJson } from './__json__/org-dns-zone-json';
 
 /**
  * IaaS Organization.
@@ -514,12 +516,12 @@ export class Org extends Entity {
 
   /**
    * Gets all DNS zones that exist within the org.
-   * @returns {Promise<Array<DnsZone>>} a promise that resolves with the list of DNS zones
+   * @returns {Promise<Array<OrgDnsZone>>} a promise that resolves with the list of DNS zones
    */
-  async getDnsZones(): Promise<Array<DnsZone>> {
+  async getOrgDnsZones(): Promise<Array<OrgDnsZone>> {
     return Iland.getHttp().get(`/orgs/${this.uuid}/dns-zones`).then((response) => {
-      const json = response.data.data as Array<DnsZoneJson>;
-      return json.map((it) => new DnsZone(it));
+      const json = response.data.data as Array<OrgDnsZoneJson>;
+      return json.map((it) => new OrgDnsZone(it));
     });
   }
 


### PR DESCRIPTION
adding the model/response actually returned by `Org.getDnsZones()` and fixing the endpoint accordingly.
swagger doc: http://doc.10.api.iland.test/1.0/#/Organizations/getDNSZones