### PR TITLE
fix DnsRecord model fields & org.updateDnsRecord endpoint

### DIFF
--- a/src/sdk/model/org/__json__/dns-record-json.ts
+++ b/src/sdk/model/org/__json__/dns-record-json.ts
@@ -8,11 +8,12 @@ export interface DnsRecordJson {
   zone_id: number;
   zone_name: string;
   host: string;
-  description: string;
+  description?: string;
   ttl?: number;
   ordering: string;
-  ip: string;
-  last_modified: number;
+  ip?: string;
+  last_modified?: number;
   value: string;
-  record_type: DnsRecordType;
+  type: DnsRecordType;
+  priority?: number;
 }

--- a/src/sdk/model/org/__mocks__/org-dns-records.ts
+++ b/src/sdk/model/org/__mocks__/org-dns-records.ts
@@ -27,7 +27,7 @@ export const MockOrgDnsRecordsJson: Array<DnsRecordJson> = [{
   ip: '1.1.1.1',
   last_modified: 123413284,
   value: '',
-  record_type: 'PTR'
+  type: 'PTR'
 }];
 
 export const MockOrgDnsRecordsResponse: Promise<AxiosResponse> = new Promise<AxiosResponse>(function(resolve) {

--- a/src/sdk/model/org/__mocks__/org-resource.ts
+++ b/src/sdk/model/org/__mocks__/org-resource.ts
@@ -58,7 +58,7 @@ export class MockOrgResource {
       ip: request.ip_address,
       last_modified: Date.now(),
       value: request.value,
-      record_type: request.type
+      type: request.type
     };
     return new Promise<AxiosResponse>(function(resolve) {
       resolve({
@@ -83,7 +83,7 @@ export class MockOrgResource {
       ip: request.ip_address,
       last_modified: Date.now(),
       value: request.value,
-      record_type: request.type
+      type: request.type
     };
     return new Promise<AxiosResponse>(function(resolve) {
       resolve({

--- a/src/sdk/model/org/__tests__/org.test.unit.ts
+++ b/src/sdk/model/org/__tests__/org.test.unit.ts
@@ -123,7 +123,7 @@ test('Properly submits request to get orgs dns records', async() => {
       expect(record.description).toBe(jsonRecord.description);
       expect(record.host).toBe(jsonRecord.host);
       expect(record.ordering).toBe(jsonRecord.ordering);
-      expect(record.recordType).toBe(jsonRecord.record_type);
+      expect(record.type).toBe(jsonRecord.type);
       expect(record.ttl).toBe(jsonRecord.ttl);
       expect(record.zoneId).toBe(jsonRecord.zone_id);
       expect(record.zoneName).toBe(jsonRecord.zone_name);
@@ -146,7 +146,7 @@ test('Properly submits request to add orgs dns record', async() => {
     expect(Iland.getHttp().post).lastCalledWith(`/orgs/${org.uuid}/dns-records`, request.json);
     expect(record.description).toBe(request.description);
     expect(record.host).toBe(request.host);
-    expect(record.recordType).toBe(request.type);
+    expect(record.type).toBe(request.type);
     expect(record.ttl).toBe(request.ttl);
     expect(record.zoneId).toBe(request.zoneId);
     expect(record.ip).toBe(request.ipAddress);
@@ -161,11 +161,11 @@ test('Properly submits request to update org dns record', async() => {
       'value', '1.1.1.1', 0, 'description', 5);
   expect(request.toString()).toBeDefined();
   return org.updateDnsRecord(request).then(function(record) {
-    expect(Iland.getHttp().put).lastCalledWith(`/orgs/${org.uuid}/dns-records`, request.json);
+    expect(Iland.getHttp().put).lastCalledWith(`/orgs/${org.uuid}/dns-records/${request.id}`, request.json);
     expect(record.id).toBe(request.id);
     expect(record.description).toBe(request.description);
     expect(record.host).toBe(request.host);
-    expect(record.recordType).toBe(request.type);
+    expect(record.type).toBe(request.type);
     expect(record.ttl).toBe(request.ttl);
     expect(record.zoneId).toBe(request.zoneId);
     expect(record.ip).toBe(request.ipAddress);

--- a/src/sdk/model/org/dns-record.ts
+++ b/src/sdk/model/org/dns-record.ts
@@ -43,18 +43,18 @@ export class DnsRecord {
 
   /**
    * Gets the record description.
-   * @returns {string}
+   * @returns {string | null} null if no description is set.
    */
-  get description(): string {
-    return this._json.description;
+  get description(): string | null {
+    return this._json.description || null;
   }
 
   /**
-   * Gets the TTL setting of the record or undefined if no TTL is set.
-   * @returns {number | undefined}
+   * Gets the TTL setting of the record.
+   * @returns {number | null} null if no TTL is set.
    */
-  get ttl(): number | undefined {
-    return this._json.ttl;
+  get ttl(): number | null {
+    return this._json.ttl ?? null;
   }
 
   /**
@@ -67,18 +67,18 @@ export class DnsRecord {
 
   /**
    * Gets the record IP address.
-   * @returns {string}
+   * @returns {string | null} null if no IP address is set and/or not applicable.
    */
-  get ip(): string {
-    return this._json.ip;
+  get ip(): string | null {
+    return this._json.ip || null;
   }
 
   /**
    * Gets the last modified date.
-   * @returns {Date}
+   * @returns {Date | null} null if not applicable.
    */
-  get lastModified(): Date {
-    return new Date(this._json.last_modified);
+  get lastModified(): Date | null {
+    return this._json.last_modified ? new Date(this._json.last_modified) : null;
   }
 
   /**
@@ -90,11 +90,19 @@ export class DnsRecord {
   }
 
   /**
-   * Gets the record's type.
+   * Gets the record type.
    * @returns {DnsRecordType}
    */
-  get recordType(): DnsRecordType {
-    return this._json.record_type;
+  get type(): DnsRecordType {
+    return this._json.type;
+  }
+
+  /**
+   * Gets the record priority. Applicable for MX record type.
+   * @returns {number | null} null if not applicable.
+   */
+  get priority(): number | null {
+    return this._json.priority ?? null;
   }
 
   /**

--- a/src/sdk/model/org/org.ts
+++ b/src/sdk/model/org/org.ts
@@ -499,7 +499,7 @@ export class Org extends Entity {
    * @returns {Promise<DnsRecord>} a promise that resolves with the updated record
    */
   async updateDnsRecord(record: DnsRecordUpdateRequest): Promise<DnsRecord> {
-    return Iland.getHttp().put(`/orgs/${this.uuid}/dns-records`, record.json).then((response) => {
+    return Iland.getHttp().put(`/orgs/${this.uuid}/dns-records/${record.id}`, record.json).then((response) => {
       const json = response.data as DnsRecordJson;
       return new DnsRecord(json);
     });

--- a/src/sdk/service/http/__mocks__/http.org.ts
+++ b/src/sdk/service/http/__mocks__/http.org.ts
@@ -78,7 +78,7 @@ export async function MockOrgPost(url: string, data?: any, config?: AxiosRequest
 
 export async function MockOrgPut(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse> {
   switch (true) {
-    case /\/orgs\/[^\/]+?\/dns-records$/.test(url): {
+    case /\/orgs\/[^\/]+?\/dns-records\/[^\/]+?$/.test(url): {
       // update org dns record
       const request = data as DnsRecordUpdateRequestJson;
       return MockOrgResource.updateDnsRecord(request);


### PR DESCRIPTION
1. adding missing `recordId` url param for [this PUT endpoint](http://doc.10.api.iland.test/1.0/#/Organizations/updateDNSRecord)

2. example API response data for `Org.getDnsRecords()`: 
```
"data": [
		{
			"id": 231610,
			"zone_id": 14064,
			"zone_name": "nat.com",
			"host": "nat.com.",
			"description": "Automatically Added",
			"ttl": 3600,
			"ordering": "1",
			"ip": null,
			"last_modified": null,
			"value": "ns0.iland.com.",
			"type": "NS",
			"priority": null
		},
		{
			"id": 234712,
			"zone_id": 14064,
			"zone_name": "nat.com",
			"host": "@",
			"description": null,
			"ttl": 3600,
			"ordering": "2",
			"ip": null,
			"last_modified": null,
			"value": "1 blah",
			"type": "MX",
			"priority": 1
		},
		{
			"id": 234715,
			"zone_id": 14064,
			"zone_name": "nat.com",
			"host": "nat.com",
			"description": null,
			"ttl": 7200,
			"ordering": "3",
			"ip": null,
			"last_modified": null,
			"value": "foo.com",
			"type": "CNAME",
			"priority": null
		}
	]
```