### PR TITLE
add cross_connect_subscriptions_total field to cloud tenant bill

### DIFF
--- a/src/sdk/model/company/__json__/cloud-tenant-bill-json.ts
+++ b/src/sdk/model/company/__json__/cloud-tenant-bill-json.ts
@@ -14,4 +14,5 @@ export interface CloudTenantBillJson {
   wan_accelerator_appliance_total: number;
   dedicated_veeam_gateway_total: number;
   rental_licenses_subscriptions_total: number;
+  cross_connect_subscriptions_total: number;
 }

--- a/src/sdk/model/company/cloud-tenant-bill.ts
+++ b/src/sdk/model/company/cloud-tenant-bill.ts
@@ -115,6 +115,14 @@ export class CloudTenantBill {
   }
 
   /**
+   * Get the cross connect subscriptions total.
+   * @returns {number}
+   */
+  get crossConnectSubscriptionsTotal(): number {
+    return this._json.cross_connect_subscriptions_total;
+  }
+
+  /**
    * Get the json representation of this class.
    * @returns {CloudTenantBillJson}
    */


### PR DESCRIPTION
[swagger doc](http://doc.10.api.iland.test/1.0/#/Companies/getCloudTenantBillingHistory)
![Screen Shot 2021-08-27 at 2 51 05 PM](https://user-images.githubusercontent.com/32935094/131181530-3f421f00-f5b3-493c-b82b-83937948a882.png)