### PR TITLE
Add param field for O365 Create / Modify Org

### DIFF
--- a/src/sdk/model/company/__json__/o365-org-create-request-json.ts
+++ b/src/sdk/model/company/__json__/o365-org-create-request-json.ts
@@ -8,6 +8,7 @@ export interface O365OrgCreateRequestJson {
   use_modern_auth: boolean;
   application_id: string | null;
   application_secret: string | null;
+  use_application_only_auth: boolean;
   is_exchange_online: boolean;
   is_teams_online: boolean;
   is_share_point_online: boolean;

--- a/src/sdk/model/company/o365-org-create-request.ts
+++ b/src/sdk/model/company/o365-org-create-request.ts
@@ -12,8 +12,8 @@ export class O365OrgCreateRequest {
   constructor(o365OrgCreateRequestJson: O365OrgCreateRequestJson);
   constructor(firstParam: string | O365OrgCreateRequest | O365OrgCreateRequestJson, account?: string, password?: string,
               useModernAuth?: boolean, applicationId?: string | null, applicationSecret?: string | null,
-              isExchangeOnline?: boolean, isTeamsOnline?: boolean, isSharePointOnline?: boolean,
-              defaultJobs?: boolean) {
+              useApplicationOnlyAuth?: boolean, isExchangeOnline?: boolean, isTeamsOnline?: boolean,
+              isSharePointOnline?: boolean, defaultJobs?: boolean) {
     if (typeof firstParam === 'string') {
       // parameters constructor
       this._json = {
@@ -23,6 +23,7 @@ export class O365OrgCreateRequest {
         use_modern_auth: useModernAuth,
         application_id: applicationId,
         application_secret: applicationSecret,
+        use_application_only_auth: useApplicationOnlyAuth,
         is_exchange_online: isExchangeOnline,
         is_teams_online: isTeamsOnline,
         is_share_point_online: isSharePointOnline,
@@ -85,6 +86,14 @@ export class O365OrgCreateRequest {
    */
   get applicationSecret(): string | null {
     return this._json.application_secret;
+  }
+
+  /**
+   * Get whether to use Azure AD application authentication.
+   * @returns {boolean}
+   */
+  get useApplicationOnlyAuth(): boolean {
+    return this._json.use_application_only_auth;
   }
 
   /**

--- a/src/sdk/model/o365/__json__/o365-modify-credentials-request-json.ts
+++ b/src/sdk/model/o365/__json__/o365-modify-credentials-request-json.ts
@@ -7,6 +7,7 @@ export interface O365ModifyCredentialsRequestJson {
   use_modern_auth: boolean;
   application_id: string | null;
   application_secret: string | null;
+  use_application_only_auth: boolean;
   is_teams_online: boolean;
   is_share_point_online: boolean;
   is_exchange_online: boolean;

--- a/src/sdk/model/o365/o365-modify-credentials-request.ts
+++ b/src/sdk/model/o365/o365-modify-credentials-request.ts
@@ -52,6 +52,14 @@ export class O365ModifyCredentialsRequest {
   }
 
   /**
+   * Get whether to use Azure AD application authentication.
+   * @returns {boolean}
+   */
+  get useApplicationOnlyAuth(): boolean {
+    return this._json.use_application_only_auth;
+  }
+
+  /**
    * Get isTeamsOnline.
    * @returns {boolean}
    */


### PR DESCRIPTION
I only included the `use_application_only_auth` field since that is the only field needed for the temporary Bug fix.
http://doc.10.api.iland.test/1.0/#/Companies/createO365Organization
http://doc.10.api.iland.test/1.0/#/Office%20365%20Backup/modifyOrganizationCredentials