### PR TITLE
Update public fields for Catalog & Media models

### DIFF
--- a/src/sdk/model/catalog/__json__/catalog-json.ts
+++ b/src/sdk/model/catalog/__json__/catalog-json.ts
@@ -6,7 +6,7 @@ import { EntityJson } from '../../common/__json__/entity-json';
 export interface CatalogJson extends EntityJson {
   location_id: string;
   shared: boolean;
-  public: boolean;
+  catalog_public: boolean;
   version: number;
   org_uuid: string;
   description: string;

--- a/src/sdk/model/catalog/catalog.ts
+++ b/src/sdk/model/catalog/catalog.ts
@@ -74,7 +74,7 @@ export class Catalog extends Entity {
    * @returns {boolean}
    */
   get isPublic(): boolean {
-    return this._json.public;
+    return this._json.catalog_public;
   }
 
   /**

--- a/src/sdk/model/media/__json__/media-json.ts
+++ b/src/sdk/model/media/__json__/media-json.ts
@@ -6,7 +6,7 @@ import { EntityJson } from '../../common/__json__/entity-json';
 export interface MediaJson extends EntityJson {
   status: number;
   size: number;
-  public: boolean;
+  is_public: boolean;
   location_id: string;
   org_uuid: string;
   catalog_uuid: string;

--- a/src/sdk/model/media/media.ts
+++ b/src/sdk/model/media/media.ts
@@ -63,7 +63,7 @@ export class Media extends Entity {
    * @returns {boolean}
    */
   get isPublic(): boolean {
-    return this._json.public;
+    return this._json.is_public;
   }
 
   /**


### PR DESCRIPTION
Currently the console is trying to read these fields as they are but they are undefined since the API is actually sending back the response with these fields as `catalog_public` & `is_public`. This has actually caused certain actions to be displayed when they shouldn't be.

In the API docs, [catalog](http://doc.10.api.iland.test/1.0/#/Catalogs/getCatalog) does show that the field is `catalog_public` but for [media](http://doc.10.api.iland.test/1.0/#/Catalogs/getMediaForCatalog) it does not show the field as `is_public` for some reason